### PR TITLE
[WIP] Feature / Add repository and service for logging [#26]

### DIFF
--- a/src/models/LoggingEntry.py
+++ b/src/models/LoggingEntry.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict
+import json
+
+
+class LoggingEntry:
+    def __init__(self, type: str = None, properties: Dict[str, Any] = None, at: str = None) -> None:
+        self._id: int = 0
+        self._type: str = type
+        self._properties_json: str = json.dumps(properties) if properties else None
+        self._at: str = at

--- a/src/repositories/LogRepository.py
+++ b/src/repositories/LogRepository.py
@@ -1,0 +1,28 @@
+from typing import List
+from sqlite3 import Connection
+from src.models.LoggingEntry import LoggingEntry
+
+
+class LogRepository:
+    def __init__(self, connection: Connection) -> None:
+        self.conn = connection
+
+    def write(self, entry: LoggingEntry) -> None:
+        try:
+            self.conn.execute(
+                "INSERT INTO Log (type, properties_json, at) VALUES (?, ?, ?)",
+                (entry._type, entry._properties_json, entry._at)
+            )
+            self.conn.commit()
+        except:
+            print("Failed to write log.")
+
+    def writeBulk(self, loggingEntries: List[LoggingEntry]) -> None:
+        try:
+            self.conn.executemany(
+                "INSERT INTO Log (type, properties_json, at) VALUES (?, ?, ?)",
+                [(entry._type, entry._properties_json, entry._at) for entry in loggingEntries]
+            )
+            self.conn.commit()
+        except:
+            print("Failed to write logs.")

--- a/src/services/BackgroundTasks.py
+++ b/src/services/BackgroundTasks.py
@@ -1,0 +1,26 @@
+import asyncio
+from functools import wraps
+from typing import Any, Callable
+from src.models.LoggingEntry import LoggingEntry
+from src.repositories.LogRepository import LogRepository
+from src.services.LoggingService import LoggingService
+from flask import g
+
+bgTasksEventLoop = asyncio.new_event_loop()
+bgTasksLoggingService = LoggingService(LogRepository(g.db))
+
+
+def backgroundTask(f: Callable[[Any], None]):
+    @wraps(f)
+    def wrapped(*args):
+        if callable(f):
+            bgTasksEventLoop.run_in_executor(None, f, *args)
+        else:
+            raise TypeError('Task must be a callable')
+
+    return wrapped
+
+
+@backgroundTask
+def loggingBackgroundTask(loggingEntry: LoggingEntry) -> None:
+    bgTasksLoggingService.log(loggingEntry)

--- a/src/services/LoggingService.py
+++ b/src/services/LoggingService.py
@@ -1,0 +1,17 @@
+from typing import List
+from src.models.LoggingEntry import LoggingEntry
+from src.repositories.LogRepository import LogRepository
+
+
+class LoggingService:
+    DEFAULT_MAX_ENTRIES = 20
+
+    def __init__(self, logRepository: LogRepository) -> None:
+        self.repo = logRepository
+        self.currentEntries: List[LoggingEntry] = []
+
+    def log(self, loggingEntry: LoggingEntry):
+        self.currentEntries.append(loggingEntry)
+        if len(self.currentEntries) >= self.DEFAULT_MAX_ENTRIES:
+            self.repo.writeBulk(self.currentEntries)
+            self.currentEntries.clear()


### PR DESCRIPTION
## Description
Add repository, service and logging entry model. Use `backgroundTask` annotation to run methods in background, without blocking the request.

## TODO
- unit tests
- register the logging background task for running before requests on certain endpoints

## Issue
Closes #26
