### PR TITLE
Fix / Avoid parsing None when APP_DB_PORT env var is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY . /app
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-CMD ["python3", "-m", "flask", "run"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$SKIP_INIT_DB" ]
+then
+    python3 -m flask init-db
+fi
+
+python3 -m flask run

--- a/src/config/Configuration.py
+++ b/src/config/Configuration.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict
 import dotenv
 
 
@@ -13,25 +12,31 @@ class __Configuration:
         self.auth_secret: str = None
 
 
-__configurations: Dict[str, __Configuration] = {}
+__configuration: __Configuration = None
 
 
-def get_configuration(envfile: str = None) -> __Configuration:
-    global __configurations
-    if envfile is None:
+def get_configuration() -> __Configuration:
+    global __configuration
+
+    if __configuration is None:
         envfile = ".env.{}".format(os.getenv("FLASK_ENV", "development"))
-
-    if envfile not in __configurations:
         dotenvcfg = dotenv.dotenv_values(envfile)
 
         cfg = __Configuration()
-        cfg.db_host = dotenvcfg.get("APP_DB_HOST")
-        cfg.db_port = int(dotenvcfg.get("APP_DB_PORT"))
-        cfg.db_user = dotenvcfg.get("APP_DB_USER")
-        cfg.db_password = dotenvcfg.get("APP_DB_PASSWORD")
-        cfg.db_file = dotenvcfg.get("APP_DB_FILE")
-        cfg.auth_secret = dotenvcfg.get("APP_AUTH_SECRET")
 
-        __configurations[envfile] = cfg
+        cfg.db_host = os.getenv("APP_DB_HOST") or dotenvcfg.get("APP_DB_HOST")
 
-    return __configurations[envfile]
+        db_port = os.getenv("APP_DB_PORT") or dotenvcfg.get("APP_DB_PORT")
+        cfg.db_port = None if db_port is None else int(db_port)
+
+        cfg.db_user = os.getenv("APP_DB_USER") or dotenvcfg.get("APP_DB_USER")
+
+        cfg.db_password = os.getenv("APP_DB_PASSWORD") or dotenvcfg.get("APP_DB_PASSWORD")
+
+        cfg.db_file = os.getenv("APP_DB_FILE") or dotenvcfg.get("APP_DB_FILE")
+
+        cfg.auth_secret = os.getenv("APP_AUTH_SECRET") or dotenvcfg.get("APP_AUTH_SECRET")
+
+        __configuration = cfg
+
+    return __configuration

--- a/test/ConfigTests.py
+++ b/test/ConfigTests.py
@@ -9,7 +9,7 @@ class ConfigTests(unittest.TestCase):
         dotenvcfg = dotenv.dotenv_values(".env.test")
 
         # Act
-        configuration = get_configuration(".env.test")
+        configuration = get_configuration()
 
         # Assert
         self.assertEqual(configuration.db_host, dotenvcfg.get("APP_DB_HOST"))


### PR DESCRIPTION
## Description
Avoid parsing `None` when `APP_DB_PORT` env var is missing.

Use environment variables as an alternative to `.env` files.

 Add `init-db` command to `Dockerfile`
